### PR TITLE
fix(design): draw content behind system bars in iOS

### DIFF
--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -13,6 +13,7 @@ struct ComposeView: UIViewControllerRepresentable {
 struct ContentView: View {
     var body: some View {
         ComposeView()
+                .ignoresSafeArea(edges: .all)
                 .ignoresSafeArea(.keyboard) // Compose has own keyboard handler
     }
 }


### PR DESCRIPTION
Modified the iOS layout to allow app content to occupy the full screen area,
like the Android's implementation(`enableEdgeToEdge()`).

**Before**

|Landing|Game|Result
|:-----:|:-----:|:-----:|
|<img width="240" src="https://github.com/user-attachments/assets/d74499da-ed56-4c72-9772-9a0c54f1b850">|<img width="240" src="https://github.com/user-attachments/assets/09cc3739-d4e3-4b72-957f-a1a1bcdb94ea">|<img width="240" src="https://github.com/user-attachments/assets/6dde37b0-cf31-444b-9e8f-22d5fe55cc60">|

**After**

|Landing|Game|Result
|:-----:|:-----:|:-----:|
|<img width="240" src="https://github.com/user-attachments/assets/1b9e2497-8bdc-4f1f-8fcc-8f6036358eca">|<img width="240" src="https://github.com/user-attachments/assets/635abd8c-2660-430a-be38-df2070c7e252">|<img width="240" src="https://github.com/user-attachments/assets/d8159166-d28a-44e3-81ea-d24e9e49f783">|

