### PR TITLE
Apply i18n in iOS

### DIFF
--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -2,6 +2,6 @@
     <string name="loading">Drum roll, please!</string>
     <string name="restart">Restart</string>
     <string name="restart_caption">Unhappy with the result?</string>
-    <string name="result_title">You choice to...</string>
+    <string name="result_title">You chose to...</string>
     <string name="error_loading_game">Please try again later.</string>
 </resources>

--- a/composeApp/src/iosMain/kotlin/common/Locale.ios.kt
+++ b/composeApp/src/iosMain/kotlin/common/Locale.ios.kt
@@ -17,15 +17,16 @@
 package common
 
 import platform.Foundation.NSLocale
-import platform.Foundation.currentLocale
-import platform.Foundation.languageCode
+import platform.Foundation.preferredLanguages
 
 class IOSLocale : Locale {
     override val language: Language
-        get() = NSLocale.currentLocale.languageCode
+        get() = NSLocale
+            .preferredLanguages()
+            .first()
             .let {
                 when (it) {
-                    "ko" -> Language.KOREAN
+                    "ko-KR" -> Language.KOREAN
                     else -> Language.ENGLISH
                 }
             }


### PR DESCRIPTION
## Issue
close #2

## Summary
Return the currently selected language, not the device's current region language.
> if I am in North America and I set my language to Japanese, my region will still be English (United States)

<img width="220" src="https://github.com/user-attachments/assets/db76a02e-8a08-4f3d-8306-240d00964bee">

## Reference
also refer to: 
- https://stackoverflow.com/a/4221416
- https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes